### PR TITLE
Remove no longer needed regexManagers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,18 +9,6 @@
   "reviewers": [
     "team:core"
   ],
-  "regexManagers": [
-    {
-      "fileMatch": [
-        "common-files/.mvn/extensions.xml"
-      ],
-      "matchStrings": [
-        "<version>(?<currentValue>.*?)<\/version>"
-      ],
-      "depNameTemplate": "io.jenkins.tools.incrementals:git-changelist-maven-extension",
-      "datasourceTemplate": "maven"
-    }
-  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
Since https://github.com/renovatebot/renovate/pull/28893 the extra configuration for `.mvn/extensions.xml` is no longer required in `renovate.json`.

Thanks to @jonesbusy for letting me know 👍🏼 

### Testing done

Verified in my own repositories that the configuration still works as expected. You may want to verify the renovate run output anyways.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
